### PR TITLE
tcmmd: Re-add D-Bus invocation completion calls

### DIFF
--- a/src/tcmmd-dbus.c
+++ b/src/tcmmd-dbus.c
@@ -89,6 +89,8 @@ handle_set_policy_cb (TcmmdManagedConnections *iface,
   g_signal_emit (self, signals[SET_POLICY], 0,
       src_ip, src_port, dest_ip, dest_port, bitrate, buffer_fill);
 
+  tcmmd_managed_connections_complete_set_policy (iface, invocation);
+
   return TRUE;
 }
 
@@ -113,6 +115,8 @@ handle_set_fixed_policy_cb (TcmmdManagedConnections *iface,
   g_signal_emit (self, signals[SET_FIXED_POLICY], 0,
       src_ip, src_port, dest_ip, dest_port, stream_rate, background_rate);
 
+  tcmmd_managed_connections_complete_set_fixed_policy (iface, invocation);
+
   return TRUE;
 }
 
@@ -132,6 +136,8 @@ handle_unset_policy_cb (TcmmdManagedConnections *iface,
     }
 
   g_signal_emit (self, signals[UNSET_POLICY], 0);
+
+  tcmmd_managed_connections_complete_unset_policy (iface, invocation);
 
   return TRUE;
 }


### PR DESCRIPTION
These were erroneously removed in commit
bca5d716c36118718d9c4897cbc1e8fd288dad05, causing leaks. They were
removed because the methods are now marked as NoReply — but because
GDBus transfers ownership of the GDBusMethodInvocation object to the
service implementation when handling a method call, it **requires** that
the service implementation call __complete__() exactly once on the
invocation object to free it.

This will cause warnings on the system bus due to sending unsolicited
replies to method calls — that’s
https://bugzilla.gnome.org/show_bug.cgi?id=755421.
