### PR TITLE
tcdemo: make the stage background opaque

### DIFF
--- a/src/tcdemo.c
+++ b/src/tcdemo.c
@@ -315,7 +315,7 @@ main (gint argc,
     gchar *argv[])
 {
   DemoData self = { NULL, };
-  ClutterColor stage_color = { 0x00, 0x00, 0x00, 0x00 };
+  ClutterColor stage_color = { 0x00, 0x00, 0x00, 0xff };
   ClutterActor *stage;
   ClutterActor *vactor;
   ClutterGstPlayback *player;


### PR DESCRIPTION
I guess this is copied from clutter-gst's `video-player` example. This normally looks black anyway because it's compositing an rgba surface but not always!
